### PR TITLE
v1: add regions endpoint abstraction functions.

### DIFF
--- a/v1/regions.go
+++ b/v1/regions.go
@@ -1,0 +1,35 @@
+package v1
+
+import (
+	"context"
+	"sort"
+
+	client "github.com/hashicorp/nomad-openapi/clients/go/v1"
+)
+
+type Regions struct {
+	client *Client
+}
+
+func (c *Client) Regions() *Regions {
+	return &Regions{client: c}
+}
+
+func (r *Regions) RegionsApi() *client.RegionsApiService {
+	return r.client.apiClient.RegionsApi
+}
+
+func (r *Regions) GetRegions(ctx context.Context) (*[]string, error) {
+	request := r.RegionsApi().GetRegions(r.client.Ctx)
+	request = r.client.setQueryOptions(ctx, request).(client.ApiGetRegionsRequest)
+
+	result, _, err := request.Execute()
+	if err != nil {
+		return nil, err
+	}
+
+	// Sort the results, so the output is always consistent.
+	sort.Strings(result)
+
+	return &result, nil
+}

--- a/v1/regions_test.go
+++ b/v1/regions_test.go
@@ -1,0 +1,22 @@
+package v1
+
+import (
+	"testing"
+
+	"github.com/hashicorp/nomad/command/agent"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegions_GetRegions(t *testing.T) {
+	t.Parallel()
+	httpTest(t, nil, func(s *agent.TestAgent) {
+
+		// Make the HTTP request
+		testClient, err := NewTestClient(s)
+		require.NoError(t, err)
+
+		result, err := testClient.Regions().GetRegions(queryOpts.Ctx())
+		require.NoError(t, err)
+		require.Equal(t, []string{"global"}, *result)
+	})
+}


### PR DESCRIPTION
The regions API path was already configured, so this just adds the abstraction into v1.

closes #34 