### PR TITLE
Refactored to request template functions

### DIFF
--- a/snippets/query-endpoint.txt
+++ b/snippets/query-endpoint.txt
@@ -1,17 +1,10 @@
 func (todo *TODO) GetTODO(ctx context.Context) (*client.TODO, *QueryMeta, error) {
-
 	request := todo.TODOApi().TODO(todo.client.Ctx)
-	request = todo.client.setQueryOptions(ctx, request).(client.TODO)
-
-	result, response, err := request.Execute()
+	result, meta, err := a.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.TODO)
+	return &final, meta, nil
 }

--- a/snippets/write-endpoint.txt
+++ b/snippets/write-endpoint.txt
@@ -1,17 +1,10 @@
 func (todo *TODO) PostTODO(ctx context.Context) (*client.TODO, *WriteMeta, error) {
-
 	request := todo.TODOApi().TODO(todo.client.Ctx)
-	request = todo.client.setWriteOptions(ctx, request).(client.TODO)
-
-	result, response, err := request.Execute()
+	result, meta, err := a.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.TODO)
+	return &final, meta, nil
 }

--- a/v1/allocations.go
+++ b/v1/allocations.go
@@ -24,15 +24,10 @@ func (a *Allocations) GetAllocations(ctx context.Context) (*[]client.AllocationL
 	request := a.AllocationsApi().GetAllocations(a.client.Ctx)
 	request = a.client.setQueryOptions(ctx, request).(client.ApiGetAllocationsRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := execQuery(request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	return result.(*[]client.AllocationListStub), meta, nil
 }

--- a/v1/allocations.go
+++ b/v1/allocations.go
@@ -20,14 +20,13 @@ func (a *Allocations) AllocationsApi() *client.AllocationsApiService {
 }
 
 func (a *Allocations) GetAllocations(ctx context.Context) (*[]client.AllocationListStub, *QueryMeta, error) {
-
 	request := a.AllocationsApi().GetAllocations(a.client.Ctx)
-	request = a.client.setQueryOptions(ctx, request).(client.ApiGetAllocationsRequest)
 
-	result, meta, err := execQuery(request)
+	result, meta, err := a.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	return result.(*[]client.AllocationListStub), meta, nil
+	final := result.([]client.AllocationListStub)
+	return &final, meta, nil
 }

--- a/v1/api.go
+++ b/v1/api.go
@@ -453,3 +453,35 @@ func cronParseNext(e *cronexpr.Expression, fromTime time.Time, spec string) (t t
 
 	return e.Next(fromTime), nil
 }
+
+type RequestExecutor interface {
+	Execute() (interface{}, *http.Response, error)
+}
+
+func execQuery(request RequestExecutor) (interface{}, *QueryMeta, error) {
+	result, response, err := request.Execute()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta, err := parseQueryMeta(response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &result, meta, nil
+}
+
+func execWrite(request RequestExecutor) (interface{}, *WriteMeta, error) {
+	result, response, err := request.Execute()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	meta, err := parseWriteMeta(response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return &result, meta, nil
+}

--- a/v1/api.go
+++ b/v1/api.go
@@ -44,9 +44,112 @@ func NewClient() (*Client, error) {
 	return c, nil
 }
 
+// ExecQuery executes a request that returns query metadata.
+func (c *Client) ExecQuery(ctx context.Context, request interface{}) (interface{}, *QueryMeta, error) {
+	typeOf := reflect.TypeOf(request)
+	valueOf := reflect.ValueOf(request)
+
+	_, ok := typeOf.MethodByName("Execute")
+	if !ok {
+		return nil, nil, errors.New("execQuery failed: no Execute method on interface")
+	}
+
+	request = setQueryOptions(ctx, request)
+
+	values := valueOf.MethodByName("Execute").Call([]reflect.Value{})
+	if !values[2].IsNil() {
+		return nil, nil, values[2].Interface().(error)
+	}
+
+	result := values[0].Interface()
+	response := values[1].Interface().(*http.Response)
+
+	meta, err := parseQueryMeta(response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result, meta, nil
+}
+
+// ExecWrite executes a request that returns write metadata.
+func (c *Client) ExecWrite(ctx context.Context, request interface{}) (interface{}, *WriteMeta, error) {
+	typeOf := reflect.TypeOf(request)
+	valueOf := reflect.ValueOf(request)
+
+	_, ok := typeOf.MethodByName("Execute")
+	if !ok {
+		return nil, nil, errors.New("ExecWrite failed: no Execute method on interface")
+	}
+
+	request = setWriteOptions(ctx, request)
+
+	values := valueOf.MethodByName("Execute").Call([]reflect.Value{})
+	if !values[2].IsNil() {
+		return nil, nil, values[2].Interface().(error)
+	}
+
+	result := values[0].Interface()
+	response := values[1].Interface().(*http.Response)
+
+	meta, err := parseWriteMeta(response)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return result, meta, nil
+}
+
+// ExecNoResponseWrite executes a request that returns write metadata, but no model.
+func (c *Client) ExecNoResponseWrite(ctx context.Context, request interface{}) (*WriteMeta, error) {
+	typeOf := reflect.TypeOf(request)
+	valueOf := reflect.ValueOf(request)
+
+	_, ok := typeOf.MethodByName("Execute")
+	if !ok {
+		return nil, errors.New("ExecNoResponseWrite failed: no Execute method on interface")
+	}
+
+	request = setWriteOptions(ctx, request)
+
+	values := valueOf.MethodByName("Execute").Call([]reflect.Value{})
+	if !values[1].IsNil() {
+		return nil, values[1].Interface().(error)
+	}
+
+	response := values[0].Interface().(*http.Response)
+
+	meta, err := parseWriteMeta(response)
+	if err != nil {
+		return nil, err
+	}
+
+	return meta, nil
+}
+
+// ExecRequest executes a client operation that does not return query or write metadata.
+func (c *Client) ExecRequest(_ context.Context, request interface{}) (interface{}, error) {
+	typeOf := reflect.TypeOf(request)
+	valueOf := reflect.ValueOf(request)
+
+	_, ok := typeOf.MethodByName("Execute")
+	if !ok {
+		return nil, errors.New("ExecRequest failed: no Execute method on interface")
+	}
+
+	values := valueOf.MethodByName("Execute").Call([]reflect.Value{})
+	if !values[2].IsNil() {
+		return nil, values[2].Interface().(error)
+	}
+
+	result := values[0].Interface()
+
+	return result, nil
+}
+
 // setQueryOptions is used to annotate the request with
 // additional query options
-func (c *Client) setQueryOptions(ctx context.Context, iface interface{}) interface{} {
+func setQueryOptions(ctx context.Context, iface interface{}) interface{} {
 	opts, ok := ctx.Value("QueryOpts").(*QueryOpts)
 	if !ok || opts == nil {
 		return iface
@@ -108,7 +211,7 @@ func (c *Client) setQueryOptions(ctx context.Context, iface interface{}) interfa
 }
 
 // setWriteOptions is used to annotate an openapi request with additional write options.
-func (c *Client) setWriteOptions(ctx context.Context, iface interface{}) interface{} {
+func setWriteOptions(ctx context.Context, iface interface{}) interface{} {
 	opts, ok := ctx.Value("WriteOpts").(*WriteOpts)
 	if !ok || opts == nil {
 		return iface
@@ -452,36 +555,4 @@ func cronParseNext(e *cronexpr.Expression, fromTime time.Time, spec string) (t t
 	}()
 
 	return e.Next(fromTime), nil
-}
-
-type RequestExecutor interface {
-	Execute() (interface{}, *http.Response, error)
-}
-
-func execQuery(request RequestExecutor) (interface{}, *QueryMeta, error) {
-	result, response, err := request.Execute()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
-}
-
-func execWrite(request RequestExecutor) (interface{}, *WriteMeta, error) {
-	result, response, err := request.Execute()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
 }

--- a/v1/jobs.go
+++ b/v1/jobs.go
@@ -29,20 +29,15 @@ func (j *Jobs) Delete(ctx context.Context, jobName string, purge, global bool) (
 	}
 
 	request := j.JobsApi().DeleteJob(j.client.Ctx, jobName)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiDeleteJobRequest)
 	request = request.Purge(purge).Global(global)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobDeregisterResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Deployment(ctx context.Context, jobName string) (*client.Deployment, *QueryMeta, error) {
@@ -51,19 +46,14 @@ func (j *Jobs) Deployment(ctx context.Context, jobName string) (*client.Deployme
 	}
 
 	request := j.JobsApi().GetJobDeployment(j.client.Ctx, jobName)
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobDeploymentRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.Deployment)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Deployments(ctx context.Context, jobName string) (*[]client.Deployment, *QueryMeta, error) {
@@ -72,19 +62,13 @@ func (j *Jobs) Deployments(ctx context.Context, jobName string) (*[]client.Deplo
 	}
 
 	request := j.JobsApi().GetJobDeployments(j.client.Ctx, jobName)
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobDeploymentsRequest)
-
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.([]client.Deployment)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Dispatch(ctx context.Context, jobName string, payload string, meta map[string]string) (*client.JobDispatchResponse, *WriteMeta, error) {
@@ -93,7 +77,6 @@ func (j *Jobs) Dispatch(ctx context.Context, jobName string, payload string, met
 	}
 
 	request := j.JobsApi().PostJobDispatch(j.client.Ctx, jobName)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobDispatchRequest)
 
 	dispatchRequest := client.NewJobDispatchRequest()
 	dispatchRequest.SetJobID(jobName)
@@ -102,17 +85,13 @@ func (j *Jobs) Dispatch(ctx context.Context, jobName string, payload string, met
 
 	request = request.JobDispatchRequest(*dispatchRequest)
 
-	result, response, err := request.Execute()
+	result, writeMeta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	writeMeta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, writeMeta, nil
+	final := result.(client.JobDispatchResponse)
+	return &final, writeMeta, nil
 }
 
 func (j *Jobs) EnforceRegister(ctx context.Context, job *client.Job, modifyIndex uint64) (*client.JobRegisterResponse, *WriteMeta, error) {
@@ -128,7 +107,6 @@ func (j *Jobs) Evaluate(ctx context.Context, jobName string, forceReschedule boo
 	}
 
 	request := j.JobsApi().PostJobEvaluate(j.client.Ctx, jobName)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobEvaluateRequest)
 
 	evalRequest := client.NewJobEvaluateRequest()
 	evalRequest.SetJobID(jobName)
@@ -138,17 +116,13 @@ func (j *Jobs) Evaluate(ctx context.Context, jobName string, forceReschedule boo
 
 	request = request.JobEvaluateRequest(*evalRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobRegisterResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) GetJob(ctx context.Context, jobName string) (*client.Job, *QueryMeta, error) {
@@ -157,37 +131,26 @@ func (j *Jobs) GetJob(ctx context.Context, jobName string) (*client.Job, *QueryM
 	}
 
 	request := j.JobsApi().GetJob(j.client.Ctx, jobName)
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.Job)
+	return &final, meta, nil
 }
 
-func (j *Jobs) GetJobs(ctx context.Context) ([]client.JobListStub, *QueryMeta, error) {
+func (j *Jobs) GetJobs(ctx context.Context) (*[]client.JobListStub, *QueryMeta, error) {
 	request := j.JobsApi().GetJobs(j.client.Ctx)
-	// TODO: Find a way to make this automatic
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobsRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return result, meta, nil
+	final := result.([]client.JobListStub)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Parse(ctx context.Context, hcl string, canonicalize, hclV1 bool) (*client.Job, error) {
@@ -204,12 +167,13 @@ func (j *Jobs) Parse(ctx context.Context, hcl string, canonicalize, hclV1 bool) 
 
 	request = request.JobsParseRequest(*parseRequest)
 
-	result, _, err := request.Execute()
+	result, err := j.client.ExecRequest(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 
-	return &result, err
+	final := result.(client.Job)
+	return &final, nil
 }
 
 type PlanOpts struct {
@@ -223,19 +187,14 @@ func (j *Jobs) PeriodicForce(ctx context.Context, jobName string) (*client.Perio
 	}
 
 	request := j.JobsApi().PostJobPeriodicForce(j.client.Ctx, jobName)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobPeriodicForceRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.PeriodicForceResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Plan(ctx context.Context, job *client.Job, diff bool) (*client.JobPlanResponse, *WriteMeta, error) {
@@ -252,19 +211,14 @@ func (j *Jobs) PlanOpts(ctx context.Context, job *client.Job, opts *PlanOpts) (*
 
 	request := j.JobsApi().PostJobPlan(j.client.Ctx, *job.ID)
 	request = request.JobPlanRequest(requestBody)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobPlanRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, err
+	final := result.(client.JobPlanResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Post(ctx context.Context, job *client.Job) (*client.JobRegisterResponse, *WriteMeta, error) {
@@ -284,7 +238,6 @@ func (j *Jobs) Register(ctx context.Context, job *client.Job, registerOpts *Regi
 	}
 
 	request := j.JobsApi().RegisterJob(j.client.Ctx)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiRegisterJobRequest)
 
 	registerRequest := client.NewJobRegisterRequest()
 	registerRequest.SetJob(*job)
@@ -300,17 +253,13 @@ func (j *Jobs) Register(ctx context.Context, job *client.Job, registerOpts *Regi
 
 	request = request.JobRegisterRequest(*registerRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobRegisterResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Revert(ctx context.Context, jobName string, versionNumber, enforcePriorVersion int32, consulToken, vaultToken string) (*client.JobRegisterResponse, *WriteMeta, error) {
@@ -319,7 +268,6 @@ func (j *Jobs) Revert(ctx context.Context, jobName string, versionNumber, enforc
 	}
 
 	request := j.JobsApi().PostJobRevert(j.client.Ctx, jobName)
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobRevertRequest)
 
 	revertRequest := client.NewJobRevertRequest()
 	revertRequest.SetJobVersion(versionNumber)
@@ -339,17 +287,13 @@ func (j *Jobs) Revert(ctx context.Context, jobName string, versionNumber, enforc
 
 	request = request.JobRevertRequest(*revertRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobRegisterResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Scale(ctx context.Context, jobName string, count int64, msg string, target map[string]string) (*client.JobRegisterResponse, *WriteMeta, error) {
@@ -364,20 +308,15 @@ func (j *Jobs) Scale(ctx context.Context, jobName string, count int64, msg strin
 	scalingRequest.SetMessage(msg)
 	scalingRequest.SetTarget(target)
 
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobScalingRequestRequest)
 	request = request.ScalingRequest(*scalingRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobRegisterResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) ScaleStatus(ctx context.Context, jobName string) (*client.JobScaleStatusResponse, *QueryMeta, error) {
@@ -386,19 +325,14 @@ func (j *Jobs) ScaleStatus(ctx context.Context, jobName string) (*client.JobScal
 	}
 
 	request := j.JobsApi().GetJobScaleStatus(j.client.Ctx, jobName)
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobScaleStatusRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobScaleStatusResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Stability(ctx context.Context, jobName string, versionNumber int32, stable bool) (*client.JobStabilityResponse, *WriteMeta, error) {
@@ -415,19 +349,13 @@ func (j *Jobs) Stability(ctx context.Context, jobName string, versionNumber int3
 
 	request = request.JobStabilityRequest(*stabilityRequest)
 
-	request = j.client.setWriteOptions(ctx, request).(client.ApiPostJobStabilityRequest)
-
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecWrite(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseWriteMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobStabilityResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Summary(ctx context.Context, jobName string) (*client.JobSummary, *QueryMeta, error) {
@@ -436,19 +364,14 @@ func (j *Jobs) Summary(ctx context.Context, jobName string) (*client.JobSummary,
 	}
 
 	request := j.JobsApi().GetJobSummary(j.client.Ctx, jobName)
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobSummaryRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobSummary)
+	return &final, meta, nil
 }
 
 func (j *Jobs) Versions(ctx context.Context, jobName string, withDiffs bool) (*client.JobVersionsResponse, *QueryMeta, error) {
@@ -457,19 +380,14 @@ func (j *Jobs) Versions(ctx context.Context, jobName string, withDiffs bool) (*c
 	}
 
 	request := j.JobsApi().GetJobVersions(j.client.Ctx, jobName).Diffs(withDiffs)
-	request = j.client.setQueryOptions(ctx, request).(client.ApiGetJobVersionsRequest)
 
-	result, response, err := request.Execute()
+	result, meta, err := j.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.JobVersionsResponse)
+	return &final, meta, nil
 }
 
 func (j *Jobs) GetLocation(job *client.Job) (*time.Location, error) {

--- a/v1/jobs_test.go
+++ b/v1/jobs_test.go
@@ -39,7 +39,7 @@ func TestJobsGet(t *testing.T) {
 		result, meta, err := testClient.Jobs().GetJobs(queryOpts.Ctx())
 		require.NoError(t, err)
 		require.NotNil(t, result)
-		require.Len(t, result, 1)
+		require.Len(t, *result, 1)
 		require.NotNil(t, meta)
 	})
 }

--- a/v1/metrics.go
+++ b/v1/metrics.go
@@ -20,12 +20,12 @@ func (m *Metrics) MetricsApi() *client.MetricsApiService {
 
 func (m *Metrics) GetMetricsSummary(ctx context.Context) (*client.MetricsSummary, error) {
 	request := m.MetricsApi().GetMetricsSummary(m.client.Ctx)
-	request = m.client.setQueryOptions(ctx, request).(client.ApiGetMetricsSummaryRequest)
 
-	result, _, err := request.Execute()
+	result, err := m.client.ExecRequest(ctx, request)
 	if err != nil {
 		return nil, err
 	}
 
-	return &result, nil
+	final := result.(client.MetricsSummary)
+	return &final, nil
 }

--- a/v1/namespaces.go
+++ b/v1/namespaces.go
@@ -24,14 +24,8 @@ func (n *Namespaces) DeleteNamespace(ctx context.Context, name string) (*WriteMe
 		return nil, errors.New("namespace name is required")
 	}
 	request := n.NamespacesApi().DeleteNamespace(n.client.Ctx, name)
-	request = n.client.setWriteOptions(ctx, request).(client.ApiDeleteNamespaceRequest)
 
-	response, err := request.Execute()
-	if err != nil {
-		return nil, err
-	}
-
-	meta, err := parseWriteMeta(response)
+	meta, err := n.client.ExecNoResponseWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -45,35 +39,23 @@ func (n *Namespaces) GetNamespace(ctx context.Context, name string) (*client.Nam
 	}
 
 	request := n.NamespacesApi().GetNamespace(n.client.Ctx, name)
-	request = n.client.setQueryOptions(ctx, request).(client.ApiGetNamespaceRequest)
-
-	result, response, err := request.Execute()
+	result, meta, err := n.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.(client.Namespace)
+	return &final, meta, nil
 }
 func (n *Namespaces) GetNamespaces(ctx context.Context) (*[]client.Namespace, *QueryMeta, error) {
 	request := n.NamespacesApi().GetNamespaces(n.client.Ctx)
-	request = n.client.setQueryOptions(ctx, request).(client.ApiGetNamespacesRequest)
-
-	result, response, err := request.Execute()
+	result, meta, err := n.client.ExecQuery(ctx, request)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	meta, err := parseQueryMeta(response)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return &result, meta, nil
+	final := result.([]client.Namespace)
+	return &final, meta, nil
 }
 
 func (n *Namespaces) PostNamespace(ctx context.Context, namespace *client.Namespace) (*WriteMeta, error) {
@@ -81,16 +63,10 @@ func (n *Namespaces) PostNamespace(ctx context.Context, namespace *client.Namesp
 		return nil, errors.New("namespace is required")
 	}
 	request := n.NamespacesApi().PostNamespace(n.client.Ctx, *namespace.Name)
-	request = n.client.setWriteOptions(ctx, request).(client.ApiPostNamespaceRequest)
 
 	request = request.Namespace2(*namespace)
 
-	response, err := request.Execute()
-	if err != nil {
-		return nil, err
-	}
-
-	meta, err := parseWriteMeta(response)
+	meta, err := n.client.ExecNoResponseWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR:

- Refactor to template methods
- Enforces setQueryOpts and setWriteOpts at framework level
- Introduces new helper methods for non opts endpoints and endpoints that don't return a value
- Updates all endpoints and associated tests to new methodology