### PR TITLE
added ExecNoMetaQuery and ExecNoMetaWrite

### DIFF
--- a/v1/api.go
+++ b/v1/api.go
@@ -141,7 +141,7 @@ func (c *Client) ExecQuery(ctx context.Context, request interface{}) (interface{
 
 	_, ok := typeOf.MethodByName("Execute")
 	if !ok {
-		return nil, nil, errors.New("execQuery failed: no Execute method on interface")
+		return nil, nil, errors.New("ExecQuery failed: no Execute method on interface")
 	}
 
 	request = c.setQueryOptions(ctx, request)
@@ -162,6 +162,29 @@ func (c *Client) ExecQuery(ctx context.Context, request interface{}) (interface{
 	}
 
 	return result, meta, nil
+}
+
+// ExecNoMetaQuery executes a request accepts QueryOpts, but does not set index or query metadata.
+func (c *Client) ExecNoMetaQuery(ctx context.Context, request interface{}) (interface{}, error) {
+	typeOf := reflect.TypeOf(request)
+
+	_, ok := typeOf.MethodByName("Execute")
+	if !ok {
+		return nil, errors.New("ExecNoMetaQuery failed: no Execute method on interface")
+	}
+
+	request = c.setQueryOptions(ctx, request)
+
+	valueOf := reflect.ValueOf(request)
+
+	values := valueOf.MethodByName("Execute").Call([]reflect.Value{})
+	if !values[2].IsNil() {
+		return nil, values[2].Interface().(error)
+	}
+
+	result := values[0].Interface()
+
+	return result, nil
 }
 
 // ExecWrite executes a request that returns write metadata.
@@ -219,6 +242,29 @@ func (c *Client) ExecNoResponseWrite(ctx context.Context, request interface{}) (
 	}
 
 	return meta, nil
+}
+
+// ExecNoMetaWrite executes a request accepts WriteOpts, but does not set index or write metadata.
+func (c *Client) ExecNoMetaWrite(ctx context.Context, request interface{}) (interface{}, error) {
+	typeOf := reflect.TypeOf(request)
+
+	_, ok := typeOf.MethodByName("Execute")
+	if !ok {
+		return nil, errors.New("ExecNoMetaWrite failed: no Execute method on interface")
+	}
+
+	request = c.setWriteOptions(ctx, request)
+
+	valueOf := reflect.ValueOf(request)
+
+	values := valueOf.MethodByName("Execute").Call([]reflect.Value{})
+	if !values[2].IsNil() {
+		return nil, values[2].Interface().(error)
+	}
+
+	result := values[0].Interface()
+
+	return result, nil
 }
 
 // ExecRequest executes a client operation that does not return query or write metadata.

--- a/v1/deployments.go
+++ b/v1/deployments.go
@@ -66,7 +66,7 @@ func (d *Deployments) Fail(ctx context.Context, deploymentID string) (*client.De
 	}
 
 	request := d.DeploymentsApi().PostDeploymentFail(d.client.Ctx, deploymentID)
-	result, err := d.client.ExecRequest(ctx, request)
+	result, err := d.client.ExecNoMetaWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -88,7 +88,7 @@ func (d *Deployments) Pause(ctx context.Context, deploymentID string, pause bool
 
 	request = request.DeploymentPauseRequest(*pauseRequest)
 
-	result, err := d.client.ExecRequest(ctx, request)
+	result, err := d.client.ExecNoMetaWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +111,7 @@ func (d *Deployments) Promote(ctx context.Context, deploymentID string, all bool
 
 	request = request.DeploymentPromoteRequest(*promoteRequest)
 
-	result, err := d.client.ExecRequest(ctx, request)
+	result, err := d.client.ExecNoMetaWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -134,7 +134,7 @@ func (d *Deployments) AllocationHealth(ctx context.Context, deploymentID string,
 
 	request = request.DeploymentAllocHealthRequest(*allocHealthRequest)
 
-	result, err := d.client.ExecRequest(ctx, request)
+	result, err := d.client.ExecNoMetaWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +155,7 @@ func (d *Deployments) Unblock(ctx context.Context, deploymentID string) (*client
 
 	request = request.DeploymentUnblockRequest(*unblockRequest)
 
-	result, err := d.client.ExecRequest(ctx, request)
+	result, err := d.client.ExecNoMetaWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/operator.go
+++ b/v1/operator.go
@@ -21,7 +21,7 @@ func (o *Operator) OperatorApi() *client.OperatorApiService {
 func (o *Operator) Raft(ctx context.Context) (*client.RaftConfiguration, error) {
 	request := o.OperatorApi().GetOperatorRaftConfiguration(o.client.Ctx)
 
-	result, err := o.client.ExecRequest(ctx, request)
+	result, err := o.client.ExecNoMetaQuery(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func (o *Operator) Peer(ctx context.Context) error {
 func (o *Operator) Autopilot(ctx context.Context) (*client.AutopilotConfiguration, error) {
 	request := o.OperatorApi().GetOperatorAutopilotConfiguration(o.client.Ctx)
 
-	result, err := o.client.ExecRequest(ctx, request)
+	result, err := o.client.ExecNoMetaQuery(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/operator.go
+++ b/v1/operator.go
@@ -67,8 +67,7 @@ func (o *Operator) UpdateAutopilot(ctx context.Context, config *client.Autopilot
 
 	request = request.AutopilotConfiguration(*updateRequest)
 
-	// TODO: Add new helper method, since this endpoint supports WriteOpts, but doesn't return WriteMeta.
-	result, err := o.client.ExecRequest(ctx, request)
+	result, err := o.client.ExecNoMetaWrite(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -80,8 +79,7 @@ func (o *Operator) UpdateAutopilot(ctx context.Context, config *client.Autopilot
 func (o *Operator) AutopilotHealth(ctx context.Context) (*client.OperatorHealthReply, error) {
 	request := o.OperatorApi().GetOperatorAutopilotHealth(o.client.Ctx)
 
-	// TODO: This endpoint also needs a helper that takes QueryOpts but returns no QueryMeta.
-	result, err := o.client.ExecRequest(ctx, request)
+	result, err := o.client.ExecNoMetaQuery(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/plugins.go
+++ b/v1/plugins.go
@@ -21,7 +21,7 @@ func (p *Plugins) PluginsApi() *client.PluginsApiService {
 
 func (p *Plugins) Get(ctx context.Context) (*[]client.CSIPluginListStub, error) {
 	request := p.PluginsApi().GetPlugins(p.client.Ctx)
-	result, err := p.client.ExecRequest(ctx, request)
+	result, err := p.client.ExecNoMetaQuery(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/v1/status.go
+++ b/v1/status.go
@@ -21,8 +21,7 @@ func (s *Status) StatusApi() *client.StatusApiService {
 func (s *Status) Leader(ctx context.Context) (*string, error) {
 	request := s.StatusApi().GetStatusLeader(s.client.Ctx)
 
-	// TODO: This endpoint also needs a helper that takes QueryOpts but returns no QueryMeta.
-	result, err := s.client.ExecRequest(ctx, request)
+	result, err := s.client.ExecNoMetaQuery(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -34,8 +33,7 @@ func (s *Status) Leader(ctx context.Context) (*string, error) {
 func (s *Status) Peers(ctx context.Context) (*[]string, error) {
 	request := s.StatusApi().GetStatusPeers(s.client.Ctx)
 
-	// TODO: This endpoint also needs a helper that takes QueryOpts but returns no QueryMeta.
-	result, err := s.client.ExecRequest(ctx, request)
+	result, err := s.client.ExecNoMetaQuery(ctx, request)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updated the following to use the new helper functions: 
- `v1/status.go` 
- `v1/operator.go`

I think this should be it, but opening it draft mode as I plan to do a quick review of the other endpoints to see if these new helpers fit there as well. 