### PR TITLE
Makefile: use `go env` rather than `uname`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 VERSION=v5.2.0
 DOCKER_IMAGE="openapitools/openapi-generator-cli:$(VERSION)"
-THIS_OS := $(shell uname | cut -d- -f1)
+THIS_OS := $(shell go env GOOS)
 
 CGO_ENABLED = 1
 CGO_CFLAGS ?=
 SDKROOT ?=
 
-ifeq (Darwin,$(THIS_OS))
+ifeq (darwin,$(THIS_OS))
 spec: CGO_ENABLED = 0
 CGO_CFLAGS=-Wno-undef-prefix
 endif


### PR DESCRIPTION
For platforms that might not have `uname`