### PR TITLE
[chore] Skip upload when running actions with `act`

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -35,7 +35,7 @@ jobs:
       # Upload the original go test log as an artifact for later review.
       - name: Upload test log
         uses: actions/upload-artifact@v2
-        if: always()
+        if: ${{ !env.ACT }}
         with:
           name: test-log
           path: /tmp/gotest.log


### PR DESCRIPTION
Allows the action to run successfully when run locally.