### PR TITLE
Improve client generation target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION=v5.2.0
 DOCKER_IMAGE="openapitools/openapi-generator-cli:$(VERSION)"
 THIS_OS := $(shell go env GOOS)
+GENERATE_CLIENT = docker run --rm --volume "$(PWD):/local" $(DOCKER_IMAGE) batch --clean
 
 CGO_ENABLED = 1
 CGO_CFLAGS ?=
@@ -21,41 +22,22 @@ spec:
 test:
 	(cd ./v1 && go test ./... -v -count=1)
 
+
+CLIENTS = v1-go v1-java v1-javascript v1-python \
+		v1-rust-reqwest v1-rust-hyper v1-ruby v1-typescript
+
 .PHONY: openapi
-v1: spec
+v1: spec $(CLIENTS)
 	@echo "==> Building v1 OpenAPI Specification and clients..."
-	@docker run \
-		--rm \
-		--volume "$(PWD):/local" \
-		 $(DOCKER_IMAGE) batch --clean /local/clients/go/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(PWD):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/java/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(PWD):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/javascript/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(PWD):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/python/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(PWD):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/rust/reqwest/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(PWD):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/rust/hyper/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(shell pwd):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/ruby/v1/config.yaml
-	@docker run \
-		--rm \
-		--volume "$(shell pwd):/local" \
-		$(DOCKER_IMAGE) batch --clean /local/clients/typescript/v1/config.yaml
+
+# these have to be before the v1-% target to special case the subfolder names
+.PHONY: v1-rust-%
+v1-rust-%:
+	@$(GENERATE_CLIENT) /local/clients/rust/$*/v1/config.yaml
+
+.PHONY: v1-%
+v1-%:
+	@$(GENERATE_CLIENT) /local/clients/$*/v1/config.yaml
 
 
 .PHONY: update-nomad


### PR DESCRIPTION
Split up the client generation target so that failures in generating individual clients can be debugged independently without having to regenerate the entire set. Use patterns to make adding new clients a little less verbose.